### PR TITLE
Allow key files to be symlinks

### DIFF
--- a/qubes.SshAgent
+++ b/qubes.SshAgent
@@ -37,8 +37,8 @@ select_key() {
     fi
     argv[$((argc++))]=$KEY_BASENAME
 
-  done < <((find "$QUBES_SSH_DIRECTORY" -mindepth 1 -maxdepth 1 -type f -readable -name '*.pub' -print0;
-            find "$QUBES_SSH_DIRECTORY" -mindepth 1 -maxdepth 1 -type d -readable ! -empty -print0) | sort -z)
+  done < <((find -L "$QUBES_SSH_DIRECTORY" -mindepth 1 -maxdepth 1 -type f -readable -name '*.pub' -print0;
+            find -L "$QUBES_SSH_DIRECTORY" -mindepth 1 -maxdepth 1 -type d -readable ! -empty -print0) | sort -z)
 
   if [ $argc -eq 0 ]; then
     echo "No SSH keys found in directory '$QUBES_SSH_DIRECTORY'" | $LOGGER


### PR DESCRIPTION
Before the qrexec service would mistakenly think there were no available keys.

Note: I'm not really sure what the second `find` call does... so I'm not sure if it needs `-L` too. What's the intention there?